### PR TITLE
feat: force arguments to be fully named

### DIFF
--- a/R/taudem-exec.R
+++ b/R/taudem-exec.R
@@ -5,6 +5,7 @@
 #' Please refer to the relative TauDEM function documentation for the syntax used to specify optional arguments.
 #' See also examples.
 #'
+#' @inheritParams rlang::args_dots_empty
 #' @param n_processes Number of processes for `mpiexec`. If `NULL` TauDEM is called without mpiexec.
 #' @param program TauDEM command (character). See examples.
 #' @param args Character vector of arguments. See examples.
@@ -31,7 +32,8 @@
 #'     "-fel", file.path(test_dir,"filled_pits.tif")
 #'   )
 #' )
-taudem_exec <- function(program, args, n_processes = getOption("traudem.n_processes", 1), quiet = getOption("traudem.quiet", FALSE)) {
+taudem_exec <- function(..., program, args, n_processes = getOption("traudem.n_processes", 1), quiet = getOption("traudem.quiet", FALSE)) {
+  rlang::check_dots_empty()
   if (!can_register_taudem()) {
     rlang::abort(
       message = c(

--- a/man/taudem_exec.Rd
+++ b/man/taudem_exec.Rd
@@ -5,6 +5,7 @@
 \title{Call TauDEM}
 \usage{
 taudem_exec(
+  ...,
   program,
   args,
   n_processes = getOption("traudem.n_processes", 1),
@@ -12,6 +13,8 @@ taudem_exec(
 )
 }
 \arguments{
+\item{...}{These dots are for future extensions and must be empty.}
+
 \item{program}{TauDEM command (character). See examples.}
 
 \item{args}{Character vector of arguments. See examples.}

--- a/man/traudem-package.Rd
+++ b/man/traudem-package.Rd
@@ -24,6 +24,7 @@ Authors:
 \itemize{
   \item Maëlle Salmon \email{maelle@cynkra.com} (\href{https://orcid.org/0000-0002-2815-0399}{ORCID})
   \item Wael Sadek
+  \item Kirill Müller \email{kirill@cynkra.com} (\href{https://orcid.org/0000-0002-1416-3412}{ORCID})
 }
 
 Other contributors:


### PR DESCRIPTION
@lucarraro  With this change, users of `taudem_exec()` will have to name arguments. Positional matching (for instance, guessing the first argument is program) and partial matching (accepting "prog" for program) are no longer possible.

``` r
test_dir <- withr::local_tempdir()
dir.create(test_dir)
#> Warning in dir.create(test_dir): '/tmp/RtmpISGG2U/file70092c95ee2d' already
#> exists
file.copy(
   system.file("test-data", "DEM.tif", package = "traudem"),
   file.path(test_dir, "DEM.tif")
 )
#> [1] TRUE
# No name
traudem::taudem_exec("pitremove", args = file.path(test_dir, "DEM.tif"))
#> Error in `traudem::taudem_exec()`:
#> ! `...` must be empty.
#> ✖ Problematic argument:
#> • ..1 = "pitremove"
#> ℹ Did you forget to name an argument?

#> Backtrace:
#>     ▆
#>  1. └─traudem::taudem_exec("pitremove", args = file.path(test_dir, "DEM.tif"))
#>  2.   └─rlang::check_dots_empty() at traudem/R/taudem-exec.R:36:2
#>  3.     └─rlang:::action_dots(...)
#>  4.       ├─base (local) try_dots(...)
#>  5.       └─rlang (local) action(...)

# Partial name

traudem::taudem_exec(prog = "pitremove", args = file.path(test_dir, "DEM.tif"))
#> Error in `traudem::taudem_exec()`:
#> ! `...` must be empty.
#> ✖ Problematic argument:
#> • prog = "pitremove"

#> Backtrace:
#>     ▆
#>  1. └─traudem::taudem_exec(prog = "pitremove", args = file.path(test_dir, "DEM.tif"))
#>  2.   └─rlang::check_dots_empty() at traudem/R/taudem-exec.R:36:2
#>  3.     └─rlang:::action_dots(...)
#>  4.       ├─base (local) try_dots(...)
#>  5.       └─rlang (local) action(...)
```

<sup>Created on 2022-10-17 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

Pro of this change (and the reason why @krlmlr and I are suggesting it):
users can only write readable code, the readers of code will clearly see what is meant.

Con:
The `...` appearance in the docs might be off-putting (but there's to my knowledge no other implementation of such an argument check).

Note that as a compromise instead of an error it could be a warning. https://rlang.r-lib.org/reference/check_dots_empty.html ([example](https://github.com/ddsjoberg/gtsummary/blob/2be3500bf99f4ca7d87d2ed032022ce4b9b92499/R/tbl_split.R#L36))

Do you agree? Would you be ok with this change being expanded for all functions?